### PR TITLE
Fix a couple of typos and markdown linting rule violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,41 +3,44 @@
 [Published site](https://codereadingclubs.github.io/www/)
 
 ## Adding or editing content
+
 ### Content is provided by markdown files
+
 - [index page](https://github.com/CodeReadingClubs/www/blob/main/content/index.md)
 - [Blog pages](https://github.com/CodeReadingClubs/www/blob/main/content/blog)
 - Blogs can be in draft (only visible in a dev environment) by adding `"draft": true` to the blog's `.md` file
 
 ### Authors are defined with name, avatar and bio required
+
 - [list of authors](https://github.com/CodeReadingClubs/www/blob/main/src/Data/Author.elm)
 - Add a new author by adding a new record to the `all` list like this:
 
-```
+```elm
 all =
     [ { name = "Author Name"
       , avatar = Pages.images.author.jpegname
       , bio = "Brief biographical info"
       }
-    ,
-      { name = "Another Author"
+    , { name = "Another Author"
       , avatar = Pages.images.author.anotherjpegname
       , bio = "Some biographical info"
       }
-
     ]
 ```
 
 ### Images files need to be added before they can be used by authors and articles
+
 - [author images](https://github.com/CodeReadingClubs/www/tree/main/images/author)
 - [article images](https://github.com/CodeReadingClubs/www/tree/main/images/article-covers)
 
 ## Deploy to GitHub pages with Travis
 
 We're using [Travis](https://travis-ci.org).
+
 - On every push to the repo, Travis will build and run tests
 - On every push or merge to `main` branch, Travis will deploy to `gh-pages`
 
-Encrypted vars can be added to `.travis.yml` using the travis cli tools as decribed in the [travis docs](https://docs.travis-ci.com/user/encryption-keys/#usage).
+Encrypted vars can be added to `.travis.yml` using the travis cli tools as described in the [travis docs](https://docs.travis-ci.com/user/encryption-keys/#usage).
 Currently configured with GITHUB_TOKEN value.
 
 ## Development Setup Instructions
@@ -48,15 +51,16 @@ Currently configured with GITHUB_TOKEN value.
 ## How this stuff works
 
 - You can tweak the `content` folder and change the `src/Main.elm` file.
-- The entrypoint file is `index.js`. That file imports `src/Main.elm`. 
+- The entrypoint file is `index.js`. That file imports `src/Main.elm`.
 - The `content` folder is turned into static pages.
 - The rest is mostly determined by logic in the Elm code.
 
 ## Further resource
+
 ### Site template generated from [dillonkearns/elm-pages-starter](https://github.com/dillonkearns/elm-pages-starter)
 
 ### Learn more about `elm-pages`
 
-- Documentation site: https://elm-pages.com
+- [Documentation site](https://elm-pages.com)
 - [Elm Package docs](https://package.elm-lang.org/packages/dillonkearns/elm-pages/latest/)
 - [`elm-pages` blog](https://elm-pages.com/blog)

--- a/content/index.md
+++ b/content/index.md
@@ -7,11 +7,11 @@ type: page
 
 It's an experiment!
 
-[Neontribe](https://www.neontribe.co.uk) were inspired by [How to teach programming (and other things)?](https://www.youtube.com/watch?v=g1ib43q3uXQ) by [Felienne Hermans](https://www.felienne.com/). 
+[Neontribe](https://www.neontribe.co.uk) were inspired by [How to teach programming (and other things)?](https://www.youtube.com/watch?v=g1ib43q3uXQ) by [Felienne Hermans](https://www.felienne.com/).
 
-At its core is the idea that the paradigm we use to teach programming is flawed. One of the most obvious ommissions is the ability to read code, both phoneticlly and analytically. Read [Felienne's blog post](https://www.felienne.com/archives/6472) for more information about the theory behind it.
+At its core is the idea that the paradigm we use to teach programming is flawed. One of the most obvious omissions is the ability to read code, both phonetically and analytically. Read [Felienne's blog post](https://www.felienne.com/archives/6472) for more information about the theory behind it.
 
-As professional developers who read code every day, we aren't suitably equiping ourselves with these building blocks.
+As professional developers who read code every day, we aren't suitably equipping ourselves with these building blocks.
 
 So Felienne developed some exercises for us to try, based on her research and teaching exercises she uses with students.
 
@@ -32,7 +32,7 @@ Participants should have had some exposure to code, but your group might include
 
 ## What code should I use?
 
-We have seen different types of clubs, you might be interested in code form your own code base, maybe in one language, or select open source code in a variety of languages. In our experience, it does not matter all that much what code you pick. The key benefit is an increased ability to understand code when reading and a more sympathetic style of writing code to be read by others, which we think you get more form the process than form the code. Some people though join a club to also learn a new language as a byproduct, when you have a few of those in your group, you might want to sitck to one language.
+We have seen different types of clubs: you might be interested in code form your own code base, maybe in one language, or select open source code in a variety of languages. In our experience, it does not matter all that much what code you pick. The key benefit is an increased ability to understand code when reading and a more sympathetic style of writing code to be read by others, which we think you get more from the process than form the code. Some people though join a club to also learn a new language as a byproduct. When you have a few of those in your group, you might want to stick to one language.
 
 We're hoping to publish a couple of starter kits soon.
 


### PR DESCRIPTION
In the README file and the homepage
