### PR TITLE
fix: add mobile nav wrapping

### DIFF
--- a/src/Layout.elm
+++ b/src/Layout.elm
@@ -60,22 +60,26 @@ header currentPath =
                 }
             ]
             Element.none
-        , Element.row
-            [ Element.paddingXY 25 8
+        , Element.wrappedRow
+            [ Element.paddingXY 25 0
             , Element.spaceEvenly
             , Element.width Element.fill
             , Element.Region.navigation
             , Element.Border.widthEach { bottom = 1, left = 0, right = 0, top = 0 }
             , Element.Border.color (Element.rgb255 17 24 31)
             ]
-            [ Element.link []
+            [ Element.link
+                [ Element.paddingXY 0 4
+                , Element.Region.heading 1
+                , Element.Border.widthXY 0 4
+                , Element.Border.color (Element.rgba 0 0 0 0)
+                ]
                 { url = "/"
                 , label =
-                    Element.row [ Font.size 30, Element.spacing 16 ]
-                        [ Element.text "Code Reading Clubs"
-                        ]
+                    Element.el [ Font.size 30, Element.spacing 16 ]
+                        (Element.text "Code Reading Clubs")
                 }
-            , Element.row [ Element.spacing 15 ]
+            , Element.row [ Element.paddingXY 0 8, Element.spacing 15 ]
                 [ highlightableLink currentPath Pages.pages.blog.directory "Our code reading adventures"
                 , githubRepoLink
                 ]

--- a/style.css
+++ b/style.css
@@ -33,6 +33,12 @@ a:hover {
   border-bottom: 4px solid var(--orange);
 }
 
+nav a.s:focus {
+  background-color: var(--yellow);
+  border-top: 4px solid var(--yellow);
+  border-bottom: 4px solid var(--yellow);
+}
+
 h2 {
   border-left: solid 20px var(--blue);
   padding-left: 10px;


### PR DESCRIPTION
Fixes #16 

- Wraps the nav at the top of the page
- Adds missing focus styles to nav links
- Adds an `<h1>` so that page headings are sequential