### PR TITLE
Update references to our site to the new .club domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Code Reading Club information site
 
-[Published site](https://code-reading.org)
-[Code of conduct](https://code-reading.org/conduct)
+[Published site](https://codereading.club)
+[Code of conduct](https://codereading.club/conduct)
 
 ## Adding or editing content
 

--- a/content/conduct.md
+++ b/content/conduct.md
@@ -39,7 +39,7 @@ As a facilitator it's important that you not only follow your code of conduct, b
 
 ## Talk to us
 
-### hello@code-reading.org
+### hello@codereading.club
 
 If you experience any behaviours or atmosphere in our groups that feels contrary to these values, please let us know. We want everyone to feel safe, equal and welcome.
 

--- a/content/index.md
+++ b/content/index.md
@@ -25,13 +25,13 @@ Want to start a club, but not sure how it works? Don't have enough people in you
 
 - Open Code Reading Club: 8 February 2022 19:00 to 20:30 (CET)
 
-#### [Get in touch](mailto:hello@code-reading.org) - [Join our mailing list](http://eepurl.com/hzYTQv) - [Sign up for a session](https://www.eventbrite.com/o/38242002183)
+#### [Get in touch](mailto:hello@codereading.club) - [Join our mailing list](http://eepurl.com/hzYTQv) - [Sign up for a session](https://www.eventbrite.com/o/38242002183)
 
 You can find the [exercises](https://github.com/CodeReadingClubs/Resources/blob/trunk/exercises.md) in our resources github repo.
 
-You can use the [pdf from github code tool](https://pdf.code-reading.org) to generate and download a pdf for your club members to print out if they want to work with code on paper.
+You can use the [pdf from github code tool](https://pdf.codereading.club) to generate and download a pdf for your club members to print out if they want to work with code on paper.
 
-You can use the [annotation app](https://annotate.code-reading.org) if your club members want to annotate on screen.
+You can use the [annotation app](https://annotate.codereading.club) if your club members want to annotate on screen.
 
 You can run your club in whatever way you want, but we recommend to meet for 1 hour 15 mins every other week.
 
@@ -49,7 +49,7 @@ We have seen different types of clubs: you might be interested in code form your
 
 ## Get in touch!
 
-If you decide to start a club, please get in touch. We'd love to hear about it, or even sit in on a session with you. Please contact [hello@code-reading.org](mailto:hello@code-reading.org) if you want to get involved, or have any suggestions.
+If you decide to start a club, please get in touch. We'd love to hear about it, or even sit in on a session with you. Please contact [hello@codereading.club](mailto:hello@codereading.club) if you want to get involved, or have any suggestions.
 
 The initial inspiration for the clubs was [How to teach programming (and other things)?](https://www.youtube.com/watch?v=g1ib43q3uXQ) by [Felienne Hermans](https://www.felienne.com/).
 

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -32,4 +32,4 @@ To keep it simple, we may use enable publicly accessible links to share these to
 
 If you have any questions or concerns about privacy or would like to talk to us about how we use and store your information, please get in touch.
 
-hello@code-reading.org
+hello@codereading.club

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -309,7 +309,7 @@ head metadata =
 
 canonicalSiteUrl : String
 canonicalSiteUrl =
-    "https://code-reading.org"
+    "https://codereading.club"
 
 
 siteTagline : String


### PR DESCRIPTION
The only reference left is the CNAME which we need to keep pointing at the old one.