### PR TITLE
Add License, CoC, and a footer

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+We strive to be inclusive and value all people equally. Our values and
+guidelines can be found in our [Code of Conduct][coc].
+
+If you experience any behaviours or atmosphere that feels contrary to these
+values, please let us know at [hello@codereading.club][email]. We want everyone
+to feel safe, equal and welcome.
+
+[coc]: https://codereading.club/conduct
+[email]: mailto:hello@codereading.club

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2022 Code Reading Club CIC
+
+Permission is hereby granted, free
+of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Layout.elm
+++ b/src/Layout.elm
@@ -114,6 +114,17 @@ footer =
             ]
             [ iconLink Pages.images.twitter "Twitter" "http://www.twitter.com/CodeReadingClub"
             ]
+        , Element.paragraph
+            [ Element.centerX
+            , Font.center
+            , Element.paddingXY 0 10
+            ]
+            [ Element.text "This site is powered by "
+            , Element.link [] { url = "https://netlify.com", label = Element.text "Netlify" }
+            , Element.text ". Its source is available on "
+            , Element.link [] { url = "https://github.com/CodeReadingClubs/www", label = Element.text "GitHub" }
+            , Element.text "."
+            ]
         ]
 
 


### PR DESCRIPTION
A bunch of stuff we need to apply to [Netlify's open source plan](https://www.netlify.com/legal/open-source-policy):

- A license file (MIT)
- A code of conduct (which mainly refers to the one on our website)
- A footer with a link to Netlify (and a link to the repo)

Eerily similar to CodeReadingClubs/annotation-tool#20

Here's what the footer looks like:

<img width="994" alt="Screen Shot 2022-02-09 at 22 54 33" src="https://user-images.githubusercontent.com/777023/153289830-229fd340-89f5-4375-9587-01489c5a9f2e.png">
